### PR TITLE
Fix some input controller issues (mapping sticks and duplicate controller names)

### DIFF
--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -313,12 +313,12 @@ namespace Ryujinx.Input.SDL2
             return value * ConvertRate;
         }
 
-        private JoyconConfigControllerStick<GamepadInputId, Common.Configuration.Hid.Controller.StickInputId> GetLogicalJoyStickConfig(StickInputId inputId)
+        private JoyconConfigControllerStick<GamepadInputId, Controller.StickInputId> GetLogicalJoyStickConfig(StickInputId inputId)
         {
             switch (inputId)
             {
                 case StickInputId.Left:
-                    if (_configuration.RightJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Left)
+                    if (_configuration.RightJoyconStick.Joystick == Controller.StickInputId.Left)
                     {
                         return _configuration.RightJoyconStick;
                     }
@@ -327,7 +327,7 @@ namespace Ryujinx.Input.SDL2
                         return _configuration.LeftJoyconStick;
                     }
                 case StickInputId.Right:
-                    if (_configuration.LeftJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Right)
+                    if (_configuration.LeftJoyconStick.Joystick == Controller.StickInputId.Right)
                     {
                         return _configuration.LeftJoyconStick;
                     }

--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -313,6 +313,32 @@ namespace Ryujinx.Input.SDL2
             return value * ConvertRate;
         }
 
+        private JoyconConfigControllerStick<GamepadInputId, Common.Configuration.Hid.Controller.StickInputId> GetLogicalJoyStickConfig(StickInputId inputId)
+        {
+            switch (inputId)
+            {
+                case StickInputId.Left:
+                    if (_configuration.RightJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Left)
+                    {
+                        return _configuration.RightJoyconStick;
+                    }
+                    else
+                    {
+                        return _configuration.LeftJoyconStick;
+                    }
+                case StickInputId.Right:
+                    if (_configuration.LeftJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Right)
+                    {
+                        return _configuration.LeftJoyconStick;
+                    }
+                    else
+                    {
+                        return _configuration.RightJoyconStick;
+                    }
+            }
+
+            return null;
+        }
         public (float, float) GetStick(StickInputId inputId)
         {
             if (inputId == StickInputId.Unbound)
@@ -343,24 +369,26 @@ namespace Ryujinx.Input.SDL2
 
             if (HasConfiguration)
             {
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.InvertStickX) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.InvertStickX))
-                {
-                    resultX = -resultX;
-                }
+                var joyconStickConfig = GetLogicalJoyStickConfig(inputId);
 
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.InvertStickY) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.InvertStickY))
+                if (joyconStickConfig != null)
                 {
-                    resultY = -resultY;
-                }
+                    if (joyconStickConfig.InvertStickX)
+                    {
+                        resultX = -resultX;
+                    }
 
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.Rotate90CW) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.Rotate90CW))
-                {
-                    float temp = resultX;
-                    resultX = resultY;
-                    resultY = -temp;
+                    if (joyconStickConfig.InvertStickY)
+                    {
+                        resultY = -resultY;
+                    }
+
+                    if (joyconStickConfig.Rotate90CW)
+                    {
+                        float temp = resultX;
+                        resultX = resultY;
+                        resultY = -temp;
+                    }
                 }
             }
 

--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -313,12 +313,12 @@ namespace Ryujinx.Input.SDL2
             return value * ConvertRate;
         }
 
-        private JoyconConfigControllerStick<GamepadInputId, Controller.StickInputId> GetLogicalJoyStickConfig(StickInputId inputId)
+        private JoyconConfigControllerStick<GamepadInputId, Common.Configuration.Hid.Controller.StickInputId> GetLogicalJoyStickConfig(StickInputId inputId)
         {
             switch (inputId)
             {
                 case StickInputId.Left:
-                    if (_configuration.RightJoyconStick.Joystick == Controller.StickInputId.Left)
+                    if (_configuration.RightJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Left)
                     {
                         return _configuration.RightJoyconStick;
                     }
@@ -327,7 +327,7 @@ namespace Ryujinx.Input.SDL2
                         return _configuration.LeftJoyconStick;
                     }
                 case StickInputId.Right:
-                    if (_configuration.LeftJoyconStick.Joystick == Controller.StickInputId.Right)
+                    if (_configuration.LeftJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Right)
                     {
                         return _configuration.LeftJoyconStick;
                     }

--- a/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
@@ -445,7 +445,7 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
 
             string GetUniqueGamepadName(IGamepad gamepad, ref int controllerNumber)
             {
-                var name = GetGamepadName(gamepad, controllerNumber);
+                string name = GetGamepadName(gamepad, controllerNumber);
 
                 if (Devices.Any(controller => controller.Name == name))
                 {
@@ -479,7 +479,7 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
 
                     if (gamepad != null)
                     {
-                        var name = GetUniqueGamepadName(gamepad, ref controllerNumber);
+                        string name = GetUniqueGamepadName(gamepad, ref controllerNumber);
                         Devices.Add((DeviceType.Controller, id, name));
                     }
                 }
@@ -697,7 +697,7 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
 
                 if (!File.Exists(path))
                 {
-                    var index = ProfilesList.IndexOf(ProfileName);
+                    int index = ProfilesList.IndexOf(ProfileName);
                     if (index != -1)
                     {
                         ProfilesList.RemoveAt(index);

--- a/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
@@ -472,7 +472,7 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
                     }
                 }
 
-                var controllerNumber = 0;
+                int controllerNumber = 0;
                 foreach (string id in _mainWindow.InputManager.GamepadDriver.GamepadsIds)
                 {
                     using IGamepad gamepad = _mainWindow.InputManager.GamepadDriver.GetGamepad(id);


### PR DESCRIPTION
Fix invert x, invert y and rotate when mapping physical left stick to logical right stick and physical right stick to logical left stick
Fix for duplicate controller names under Ava when two controllers of the same type are attached (e.g. two Xbox Controllers)