### PR TITLE
infra: don't repackage appimages and fix zsync files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build AppImage
         if: github.event_name == 'pull_request' && matrix.platform.os == 'ubuntu-latest'
         run: |
-          PLATFORM_NAME="${{ matrix.platform.name }}"
+          ARCH_NAME="${RUNNER_ARCH,,}"
 
           sudo apt install -y zsync desktop-file-utils appstream
 
@@ -93,15 +93,17 @@ jobs:
           wget -q -O tools/appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
           chmod +x tools/appimagetool
 
-          if [ "$PLATFORM_NAME" = "linux-x64" ]; then
+          # Explicitly set $ARCH for appimagetool
+          if [ "$ARCH_NAME" = "x64" ]; then
             export ARCH=x86_64
-          elif [ "$PLATFORM_NAME" = "linux-arm64" ]; then
+          elif [ "$ARCH_NAME" = "arm64" ]; then
             export ARCH=aarch64
           else
-            echo "Unexpected PLATFORM_NAME "$PLATFORM_NAME""
+            echo "Unexpected ARCH_NAME "$ARCH_NAME""
             exit 1
           fi
 
+          export UFLAG="gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|*-$ARCH_NAME.AppImage.zsync"
           BUILDDIR=publish OUTDIR=publish_appimage distribution/linux/appimage/build-appimage.sh
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,14 +106,17 @@ jobs:
       - name: Packing Windows builds
         if: matrix.platform.os == 'windows-latest'
         run: |
+          BUILD_VERSION="${{ steps.version_info.outputs.build_version }}"
+          ZIP_OS_NAME="${{ matrix.platform.zip_os_name }}"
+
           pushd publish_ava
           cp Ryujinx.exe Ryujinx.Ava.exe
-          7z a ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip *
-          7z a ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip *
+          7z a ../release_output/ryujinx-$BUILD_VERSION-$ZIP_OS_NAME.zip *
+          7z a ../release_output/test-ava-ryujinx-$BUILD_VERSION-$ZIP_OS_NAME.zip *
           popd
 
           pushd publish_sdl2_headless
-          7z a ../release_output/sdl2-ryujinx-headless-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.zip *
+          7z a ../release_output/sdl2-ryujinx-headless-$BUILD_VERSION-$ZIP_OS_NAME.zip *
           popd
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,8 @@ jobs:
       - name: Build AppImage (Linux)
         if: matrix.platform.os == 'ubuntu-latest'
         run: |
-          PLATFORM_NAME="${{ matrix.platform.name }}"
+          BUILD_VERSION="${{ steps.version_info.outputs.build_version }}"
+          ARCH_NAME="${RUNNER_ARCH,,}"
 
           sudo apt install -y zsync desktop-file-utils appstream
 
@@ -131,37 +132,42 @@ jobs:
           wget -q -O tools/appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
           chmod +x tools/appimagetool
 
-          if [ "$PLATFORM_NAME" = "linux-x64" ]; then
+          # Explicitly set $ARCH for appimagetool
+          if [ "$ARCH_NAME" = "x64" ]; then
             export ARCH=x86_64
-          elif [ "$PLATFORM_NAME" = "linux-arm64" ]; then
+          elif [ "$ARCH_NAME" = "arm64" ]; then
             export ARCH=aarch64
           else
-            echo "Unexpected PLATFORM_NAME "$PLATFORM_NAME""
+            echo "Unexpected ARCH_NAME "$ARCH_NAME""
             exit 1
           fi
-          export VERSION=${{ steps.version_info.outputs.build_version }}          
 
+          export UFLAG="gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|*-$ARCH_NAME.AppImage.zsync"
           BUILDDIR=publish_ava OUTDIR=publish_ava_appimage distribution/linux/appimage/build-appimage.sh
+
+          # Add to release output
+          pushd publish_ava_appimage
+          mv Ryujinx.AppImage ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage
+          mv Ryujinx.AppImage.zsync ../release_output/ryujinx-$BUILD_VERSION-$ARCH_NAME.AppImage.zsync
+          popd
         shell: bash
 
       - name: Packing Linux builds
         if: matrix.platform.os == 'ubuntu-latest'
         run: |
+          BUILD_VERSION="${{ steps.version_info.outputs.build_version }}"
+          ZIP_OS_NAME="${{ matrix.platform.zip_os_name }}"
+
           pushd publish_ava
           cp Ryujinx Ryujinx.Ava
           chmod +x Ryujinx.sh Ryujinx Ryujinx.Ava
-          tar -czvf ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz *
-          tar -czvf ../release_output/test-ava-ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz *
+          tar -czvf ../release_output/ryujinx-$BUILD_VERSION-$ZIP_OS_NAME.tar.gz *
+          tar -czvf ../release_output/test-ava-ryujinx-$BUILD_VERSION-$ZIP_OS_NAME.tar.gz *
           popd
 
           pushd publish_sdl2_headless
           chmod +x Ryujinx.sh Ryujinx.Headless.SDL2
-          tar -czvf ../release_output/sdl2-ryujinx-headless-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}.tar.gz *
-          popd
-
-          # AppImage archive
-          pushd publish_ava_appimage
-          mv ./*AppImage* ../release_output
+          tar -czvf ../release_output/sdl2-ryujinx-headless-$BUILD_VERSION-$ZIP_OS_NAME.tar.gz *
           popd
         shell: bash
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
 
           # AppImage archive
           pushd publish_ava_appimage
-          tar -czvf ../release_output/ryujinx-${{ steps.version_info.outputs.build_version }}-${{ matrix.platform.zip_os_name }}-AppImage.tar.gz *
+          mv ./*AppImage* ../release_output
           popd
         shell: bash
 
@@ -169,7 +169,7 @@ jobs:
         with:
           name: ${{ steps.version_info.outputs.build_version }}
           tag: ${{ steps.version_info.outputs.build_version }}
-          artifacts: "release_output/*.tar.gz,release_output/*.zip"
+          artifacts: "release_output/*.tar.gz,release_output/*.zip,release_output/*AppImage*"
           draft: "true"
           omitBody: true
           #omitBodyDuringUpdate: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
             echo "Unexpected PLATFORM_NAME "$PLATFORM_NAME""
             exit 1
           fi
+          export VERSION=${{ steps.version_info.outputs.build_version }}          
 
           BUILDDIR=publish_ava OUTDIR=publish_ava_appimage distribution/linux/appimage/build-appimage.sh
         shell: bash

--- a/distribution/linux/appimage/build-appimage.sh
+++ b/distribution/linux/appimage/build-appimage.sh
@@ -23,7 +23,7 @@ mkdir -p "$OUTDIR"
 
 appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 21 \
     -u "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|Ryujinx|latest|*-$ARCH.AppImage.zsync" \
-    AppDir "$OUTDIR"/Ryujinx-"$ARCH".AppImage
+    AppDir "$OUTDIR"/Ryujinx-"$VERSION"-"$ARCH".AppImage
 
 # move zsync file needed for delta updates
 mv ./*.AppImage.zsync "$OUTDIR"

--- a/distribution/linux/appimage/build-appimage.sh
+++ b/distribution/linux/appimage/build-appimage.sh
@@ -6,6 +6,7 @@ cd "$ROOTDIR"
 
 BUILDDIR=${BUILDDIR:-publish}
 OUTDIR=${OUTDIR:-publish_appimage}
+UFLAG=${UFLAG:-"gh-releases-zsync|ryujinx-mirror|ryujinx|latest|*-x64.AppImage.zsync"}
 
 rm -rf AppDir
 mkdir -p AppDir/usr/bin
@@ -22,8 +23,8 @@ chmod +x AppDir/AppRun AppDir/usr/bin/Ryujinx*
 mkdir -p "$OUTDIR"
 
 appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 21 \
-    -u "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|Ryujinx|latest|*-$ARCH.AppImage.zsync" \
-    AppDir "$OUTDIR"/Ryujinx-"$VERSION"-"$ARCH".AppImage
+    -u "$UFLAG" \
+    AppDir "$OUTDIR"/Ryujinx.AppImage
 
-# move zsync file needed for delta updates
+# Move zsync file needed for delta updates
 mv ./*.AppImage.zsync "$OUTDIR"

--- a/distribution/linux/appimage/build-appimage.sh
+++ b/distribution/linux/appimage/build-appimage.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -eu
 
 ROOTDIR="$(readlink -f "$(dirname "$0")")"/../../../
 cd "$ROOTDIR"
@@ -8,7 +8,7 @@ BUILDDIR=${BUILDDIR:-publish}
 OUTDIR=${OUTDIR:-publish_appimage}
 
 rm -rf AppDir
-mkdir -p AppDir/usr/bin/bin
+mkdir -p AppDir/usr/bin
 
 cp distribution/linux/Ryujinx.desktop AppDir/Ryujinx.desktop
 cp distribution/linux/appimage/AppRun AppDir/AppRun
@@ -22,8 +22,8 @@ chmod +x AppDir/AppRun AppDir/usr/bin/Ryujinx*
 mkdir -p "$OUTDIR"
 
 appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 21 \
-    -u "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|Ryujinx|latest|*.AppImage.zsync" \
-    AppDir "$OUTDIR"/Ryujinx.AppImage
+    -u "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|Ryujinx|latest|*-$ARCH.AppImage.zsync" \
+    AppDir "$OUTDIR"/Ryujinx-"$ARCH".AppImage
 
-# ??
+# move zsync file needed for delta updates
 mv ./*.AppImage.zsync "$OUTDIR"


### PR DESCRIPTION
Now delta updates work: 

![image](https://github.com/user-attachments/assets/a73c845e-5f8e-4039-bf91-48c80f4b2329)

This is how the tool updates: 

![image](https://github.com/user-attachments/assets/29bb688d-8be8-4e88-9fca-f57a8892e0a3)

EDIT: I also just included the version in the title of the AppImage as the [spec recommends](https://github.com/AppImage/AppImageSpec/blob/master/draft.md#type-2-image-format).