### PR TITLE
Fix divide by zero when recovering from missed draw (Vulkan)

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
@@ -56,7 +56,9 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 // May need to restride the vertex buffer.
 
-                if (gd.NeedsVertexBufferAlignment(AttributeScalarAlignment, out int alignment) && (_stride % alignment) != 0)
+                // Fix divide by zero when recovering from missed draw (Oct. 16 2024)
+                // (fixes crash in 'Baldo: The Guardian Owls' opening cutscene)
+                if (gd.NeedsVertexBufferAlignment(AttributeScalarAlignment, out int alignment) && alignment != 0 && (_stride % alignment) != 0) 
                 {
                     autoBuffer = gd.BufferManager.GetAlignedVertexBuffer(cbs, _handle, _offset, _size, _stride, alignment);
 

--- a/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
@@ -55,10 +55,10 @@ namespace Ryujinx.Graphics.Vulkan
             if (_handle != BufferHandle.Null)
             {
                 // May need to restride the vertex buffer.
-
+                // 
                 // Fix divide by zero when recovering from missed draw (Oct. 16 2024)
                 // (fixes crash in 'Baldo: The Guardian Owls' opening cutscene)
-                if (gd.NeedsVertexBufferAlignment(AttributeScalarAlignment, out int alignment) && alignment != 0 && (_stride % alignment) != 0) 
+                if (gd.NeedsVertexBufferAlignment(AttributeScalarAlignment, out int alignment) && alignment != 0 && (_stride % alignment) != 0)
                 {
                     autoBuffer = gd.BufferManager.GetAlignedVertexBuffer(cbs, _handle, _offset, _size, _stride, alignment);
 


### PR DESCRIPTION
Fixes a hard crash in 'Baldo: The Guardian Owls' opening cutscene when using Vulkan. Likely fixes other games as well considering the non-zero check should have been there in the first place